### PR TITLE
Add parameter for WebsocketAdvertiseAddress

### DIFF
--- a/config_defaults.json
+++ b/config_defaults.json
@@ -33,7 +33,8 @@
     },
     "websocket": {
       "enabled": true,
-      "bindAddress": "localhost:1888"
+      "bindAddress": "localhost:1888",
+      "advertiseAddress": ""
     },
     "tcp": {
       "enabled": false,

--- a/core/mqtt/component.go
+++ b/core/mqtt/component.go
@@ -59,6 +59,7 @@ func provide(c *dig.Container) error {
 			mqtt.WithTopicCleanupThresholdRatio(ParamsMQTT.Subscriptions.TopicsCleanupThresholdRatio),
 			mqtt.WithWebsocketEnabled(ParamsMQTT.Websocket.Enabled),
 			mqtt.WithWebsocketBindAddress(ParamsMQTT.Websocket.BindAddress),
+			mqtt.WithWebsocketAdvertiseAddress(ParamsMQTT.Websocket.AdvertiseAddress),
 			mqtt.WithTCPEnabled(ParamsMQTT.TCP.Enabled),
 			mqtt.WithTCPBindAddress(ParamsMQTT.TCP.BindAddress),
 			mqtt.WithTCPAuthEnabled(ParamsMQTT.TCP.Auth.Enabled),

--- a/core/mqtt/params.go
+++ b/core/mqtt/params.go
@@ -13,8 +13,9 @@ type ParametersMQTT struct {
 	}
 
 	Websocket struct {
-		Enabled     bool   `default:"true" usage:"whether to enable the websocket connection of the MQTT broker"`
-		BindAddress string `default:"localhost:1888" usage:"the websocket bind address on which the MQTT broker listens on"`
+		Enabled          bool   `default:"true" usage:"whether to enable the websocket connection of the MQTT broker"`
+		BindAddress      string `default:"localhost:1888" usage:"the websocket bind address on which the MQTT broker listens on"`
+		AdvertiseAddress string `default:"" usage:"the address of the websocket of the MQTT broker which is advertised to the INX Server (optional)."`
 	}
 
 	TCP struct {

--- a/core/mqtt/server.go
+++ b/core/mqtt/server.go
@@ -107,7 +107,13 @@ func (s *Server) Run(ctx context.Context) {
 		ctxRegister, cancelRegister := context.WithTimeout(ctx, 5*time.Second)
 
 		s.LogInfo("Registering API route ...")
-		if err := deps.NodeBridge.RegisterAPIRoute(ctxRegister, APIRoute, s.brokerOptions.WebsocketBindAddress); err != nil {
+
+		advertisedAddress := s.brokerOptions.WebsocketBindAddress
+		if s.brokerOptions.WebsocketAdvertiseAddress != "" {
+			advertisedAddress = s.brokerOptions.WebsocketAdvertiseAddress
+		}
+
+		if err := deps.NodeBridge.RegisterAPIRoute(ctxRegister, APIRoute, advertisedAddress); err != nil {
 			s.LogErrorfAndExit("failed to register API route via INX: %s", err.Error())
 		}
 		s.LogInfo("Registering API route ... done")

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -138,10 +138,11 @@ Example:
 
 ### <a id="mqtt_websocket"></a> Websocket
 
-| Name        | Description                                                    | Type    | Default value    |
-| ----------- | -------------------------------------------------------------- | ------- | ---------------- |
-| enabled     | Whether to enable the websocket connection of the MQTT broker  | boolean | true             |
-| bindAddress | The websocket bind address on which the MQTT broker listens on | string  | "localhost:1888" |
+| Name             | Description                                                                                       | Type    | Default value    |
+| ---------------- | ------------------------------------------------------------------------------------------------- | ------- | ---------------- |
+| enabled          | Whether to enable the websocket connection of the MQTT broker                                     | boolean | true             |
+| bindAddress      | The websocket bind address on which the MQTT broker listens on                                    | string  | "localhost:1888" |
+| advertiseAddress | The address of the websocket of the MQTT broker which is advertised to the INX Server (optional). | string  | ""               |
 
 ### <a id="mqtt_tcp"></a> TCP
 
@@ -182,7 +183,8 @@ Example:
       },
       "websocket": {
         "enabled": true,
-        "bindAddress": "localhost:1888"
+        "bindAddress": "localhost:1888",
+        "advertiseAddress": ""
       },
       "tcp": {
         "enabled": false,

--- a/pkg/mqtt/broker_options.go
+++ b/pkg/mqtt/broker_options.go
@@ -16,12 +16,14 @@ type BrokerOptions struct {
 
 	// WebsocketEnabled defines whether to enable the websocket connection of the MQTT broker.
 	WebsocketEnabled bool
-	// WebsocketBindAddress the websocket bind address on which the MQTT broker listens on.
+	// WebsocketBindAddress defines the websocket bind address on which the MQTT broker listens on.
 	WebsocketBindAddress string
+	// WebsocketAdvertiseAddress defines the address of the websocket of the MQTT broker which is advertised to the INX Server (optional).
+	WebsocketAdvertiseAddress string
 
 	// TCPEnabled defines whether to enable the TCP connection of the MQTT broker.
 	TCPEnabled bool
-	// TCPBindAddress the TCP bind address on which the MQTT broker listens on.
+	// TCPBindAddress defines the TCP bind address on which the MQTT broker listens on.
 	TCPBindAddress string
 
 	// TCPAuthEnabled defines whether to enable auth for TCP connections.
@@ -46,6 +48,7 @@ var defaultBrokerOpts = []BrokerOption{
 	WithTopicCleanupThresholdRatio(1.0),
 	WithWebsocketEnabled(true),
 	WithWebsocketBindAddress("localhost:1888"),
+	WithWebsocketAdvertiseAddress(""),
 	WithTCPEnabled(false),
 	WithTCPBindAddress("localhost:1883"),
 	WithTCPAuthEnabled(false),
@@ -118,6 +121,13 @@ func WithWebsocketEnabled(websocketEnabled bool) BrokerOption {
 func WithWebsocketBindAddress(websocketBindAddress string) BrokerOption {
 	return func(options *BrokerOptions) {
 		options.WebsocketBindAddress = websocketBindAddress
+	}
+}
+
+// WithWebsocketBindAddress sets the address of the websocket of the MQTT broker which is advertised to the INX Server (optional).
+func WithWebsocketAdvertiseAddress(websocketAdvertiseAddress string) BrokerOption {
+	return func(options *BrokerOptions) {
+		options.WebsocketAdvertiseAddress = websocketAdvertiseAddress
 	}
 }
 


### PR DESCRIPTION
This PR introduces the AdvertiseAddress config parameter for the websocket, which simplifies the setup in some private network environments.